### PR TITLE
Add npm-debug task to show package.json contents

### DIFF
--- a/src/leiningen/npm.clj
+++ b/src/leiningen/npm.clj
@@ -74,6 +74,13 @@
      (with-json-file "package.json" (project->package project) project
        (apply invoke project args))))
 
+(defn npm-debug
+  [project]
+  (environmental-consistency project)
+  (with-json-file "package.json" (project->package project) project
+    (println (str "lein-npm generated package.json:\n"))
+    (println (slurp "package.json"))))
+
 (defn install-deps
   [project]
   (environmental-consistency project)

--- a/src/leiningen/npm_debug.clj
+++ b/src/leiningen/npm_debug.clj
@@ -1,0 +1,9 @@
+(ns leiningen.npm-debug
+  (:require [leiningen.help :as help]
+            [leiningen.core.main :as main]
+            [leiningen.npm :as npm]))
+
+(defn npm-debug
+  "Show debugging information for the npm task."
+  ([project]
+     (npm/npm-debug project)))


### PR DESCRIPTION
This is just the "npm-debug" task from #2, now that the bower parts are no longer relevant.

This is useful to troubleshoot generated package.json contents. I find it helps to spot discrepancies with a plain old package.json that I'm migrating to a lein environment.

I'm open to changing the UI -- it doesn't have to be a task, or called npm-debug. But it would be helpful to add some equivalent behaviour.

Thanks.
