### PR TITLE
Use npm start to hook lein run

### DIFF
--- a/src/leiningen/npm.clj
+++ b/src/leiningen/npm.clj
@@ -58,7 +58,9 @@
           {:name (project :name)
            :description (project :description)
            :version (project :version)
-           :dependencies (transform-deps (resolve-node-deps project))})
+           :dependencies (transform-deps (resolve-node-deps project))}
+          (when-let [main (project :main)]
+            {:scripts {:start (str "node " main)}}))
    {:pretty true}))
 
 (defn write-json-file

--- a/src/leiningen/npm/node_exec.clj
+++ b/src/leiningen/npm/node_exec.clj
@@ -1,6 +1,6 @@
 (ns leiningen.npm.node-exec
   (:require [leiningen.npm.process :refer [exec]]
-            [leiningen.npm :refer [install-deps]]
+            [leiningen.npm :refer [install-deps npm]]
             [clojure.java.io :as io]
             [robert.hooke :as hooke]
             [leiningen.run]))
@@ -14,7 +14,7 @@
              (re-matches #".*\.js$" main))
       (do
         (install-deps project)
-        (exec (project :root) (concat ["node" main] (rest args))))
+        (apply npm project (cons "start" (rest args))))
       (apply f args))))
 
 (defn install-hooks []


### PR DESCRIPTION
I try to be quiet about missing `:main` key in `project.clj`, `lein run` quietly returns.
