### PR TITLE
Handle :repositories containing {:username :env/foo, :password :env/bar}

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-npm "0.4.0"
+(defproject arohner/lein-npm "0.4.1"
   :description "Manage Node dependencies for CLJS projects"
   :url "https://github.com/bodil/lein-npm"
   :license {:name "Apache License, version 2.0"

--- a/src/leiningen/npm/deps.clj
+++ b/src/leiningen/npm/deps.clj
@@ -53,8 +53,8 @@
     (when (not (contains? exclusions jar-project-name))
       jar-project-deps)))
 
-(defn resolve-repositories [project]
-  (->> (:repositories project)
+(defn resolve-repositories [repos]
+  (->> repos
        (map (fn [[name repo]]
               [name (leiningen.core.user/resolve-credentials repo)]))
        (into {})))

--- a/src/leiningen/npm/deps.clj
+++ b/src/leiningen/npm/deps.clj
@@ -53,13 +53,19 @@
     (when (not (contains? exclusions jar-project-name))
       jar-project-deps)))
 
+(defn resolve-repositories [project]
+  (->> (:repositories project)
+       (map (fn [[name repo]]
+              [name (leiningen.core.user/resolve-credentials repo)]))
+       (into {})))
+
 (defn- resolve-in-jar-deps
   "Resolves a given lookup-key in all the project definitions for jar
   dependencies of a project. Excludes any Clojure project jars that
   are named in a set of exclusions."
   [lookup-key project exclusions]
   (->> (a/resolve-dependencies :coordinates (project :dependencies)
-                               :repositories (project :repositories))
+                               :repositories (resolve-repositories (project :repositories)))
        (a/dependency-files)
        (map #(JarFile. %))
        (keep (partial resolve-in-jar-dep lookup-key exclusions))


### PR DESCRIPTION
This calls leiningen.core.user/resolve-credentials on repositories. It fixes a bug 

where if you have in your project.clj

```clojure
:repositories {"a-repo" {:url "https://my-repo.com"                        
                                   :username :env/foo
                                   :password :env/bar}}
```

you'll get this stacktrace when running `lein npm install`
```clojure

java.lang.IllegalArgumentException: No matching ctor found for class org.sonatype.aether.repository.Authentication
 at clojure.lang.Reflector.invokeConstructor (Reflector.java:183)
    cemerick.pomegranate.aether$set_authentication.invoke (aether.clj:165)
    cemerick.pomegranate.aether$make_repository.invoke (aether.clj:185)
    cemerick.pomegranate.aether$resolve_dependencies_STAR_$fn__194.invoke (aether.clj:712)
    clojure.core$map$fn__4245.invoke (core.clj:2557)
    clojure.lang.LazySeq.sval (LazySeq.java:40)
    clojure.lang.LazySeq.seq (LazySeq.java:49)
    clojure.lang.ChunkedCons.chunkedNext (ChunkedCons.java:59)
    clojure.lang.ChunkedCons.next (ChunkedCons.java:43)
    clojure.lang.PersistentVector.create (PersistentVector.java:51)
    clojure.lang.LazilyPersistentVector.create (LazilyPersistentVector.java:31)
    clojure.core$vec.invoke (core.clj:354)
    cemerick.pomegranate.aether$resolve_dependencies_STAR_.doInvoke (aether.clj:712)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:624)
    cemerick.pomegranate.aether$resolve_dependencies.doInvoke (aether.clj:729)
    clojure.lang.RestFn.invoke (RestFn.java:457)
    leiningen.npm.deps$resolve_in_jar_deps.invoke (deps.clj:62)
    leiningen.npm.deps$resolve_node_deps.invoke (deps.clj:81)
    leiningen.npm.deps$resolve_node_deps.invoke (deps.clj:85)
    leiningen.npm$project__GT_package.invoke (npm.clj:60)
    leiningen.npm$npm.doInvoke (npm.clj:101)
    clojure.lang.RestFn.invoke (RestFn.java:423)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invoke (core.clj:626)
    leiningen.core.main$partial_task$fn__4230.doInvoke (main.clj:234)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:626)
    leiningen.core.main$apply_task.invoke (main.clj:281)
    lein_environ.plugin$write_env_to_file.invoke (plugin.clj:11)
    clojure.lang.Var.invoke (Var.java:394)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invoke (core.clj:626)
    robert.hooke$compose_hooks$fn__9820.doInvoke (hooke.clj:40)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:624)
    robert.hooke$run_hooks.invoke (hooke.clj:46)
    robert.hooke$prepare_for_hooks$fn__9825$fn__9826.doInvoke (hooke.clj:54)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.AFunction$1.doInvoke (AFunction.java:29)
    clojure.lang.RestFn.invoke (RestFn.java:436)
    leiningen.core.main$resolve_and_apply.invoke (main.clj:287)
    leiningen.core.main$_main$fn__4295.invoke (main.clj:357)
    leiningen.core.main$_main.doInvoke (main.clj:344)
    clojure.lang.RestFn.invoke (RestFn.java:421)
    clojure.lang.Var.invoke (Var.java:383)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.core$apply.invoke (core.clj:624)
    clojure.main$main_opt.invoke (main.clj:315)
    clojure.main$main.doInvoke (main.clj:420)
    clojure.lang.RestFn.invoke (RestFn.java:457)
    clojure.lang.Var.invoke (Var.java:394)
    clojure.lang.AFn.applyToHelper (AFn.java:165)
    clojure.lang.Var.applyTo (Var.java:700)
    clojure.main.main (main.java:37)

```