### PR TITLE
Incredibly pedantic change proposal: Use 'npm' lower-case, as that is…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ To enable lein-npm for your project, put the following in the
 [lein-npm "0.5.0"]
 ```
 
-## Managing NPM dependencies
+## Managing npm dependencies
 
-You can specify a project's NPM dependencies by adding a
+You can specify a project's npm dependencies by adding a
 `:node-dependencies` key in your `project.clj`:
 
 ```clojure
@@ -26,9 +26,9 @@ These dependencies, and any `:node-dependencies` of packages pulled in
 through the regular `:dependencies`, will be installed through NPM
 when you run either `lein npm install` or `lein deps`.
 
-## Invoking NPM
+## Invoking npm
 
-You can execute NPM commands that require the presence of a
+You can execute npm commands that require the presence of a
 `package.json` file using the `lein npm` command. This command creates
 a temporary `package.json` based on your `project.clj` before invoking
 the NPM command you specify. The keys `name`, `description`, `version` and


### PR DESCRIPTION
… what npm wants

I'm not 100% sure why I'm making the pull request, but npm likes to be lower-case. I know I could have spent this time learning about something new (like datalog) or perhaps sleeping or writing an epic poem, or perhaps even getting a job. But instead, I changed the word NPM to npm four times, and then wrote this bit of gibberish to tell you about it.

According the the faq, npm should always be lower-case, except in man pages. This readme isn't really a man page. https://docs.npmjs.com/misc/faq#is-it-npm-or-npm-or-npm