### PR TITLE
Create npm-root directory if it doesn't exist

### DIFF
--- a/src/leiningen/npm.clj
+++ b/src/leiningen/npm.clj
@@ -70,6 +70,7 @@
 (defn- write-ephemeral-file
   [file content]
   (doto file
+    (-> .getParentFile .mkdirs)
     (spit content)
     (.deleteOnExit)))
 


### PR DESCRIPTION
As reported in #26 an exception is thrown when lein-npm is invoked while a root directory does not exist.

As a convenience, this fix gets lein-npm to optimistically create the root directory, which covers the annoying common case where a user forgets to manually create a directory beforehand.

It doesn't deal with other edge cases such as incorrect permissions, pre-existing paths with the wrong type, etc, which will all still throw ugly exceptions. It might be nice to work out a more general error handling/reporting mechanism separately.