### PR TITLE
Simplest possible implementation of dump-package subcommand

### DIFF
--- a/src/leiningen/npm.clj
+++ b/src/leiningen/npm.clj
@@ -67,11 +67,15 @@
           (get-in project [:npm :package]))
    {:pretty true}))
 
-(defn- write-ephemeral-file
+(defn- write-file
   [file content]
   (doto file
     (-> .getParentFile .mkdirs)
-    (spit content)
+    (spit content)))
+
+(defn- write-ephemeral-file
+  [file content]
+  (doto (write-file file content)
     (.deleteOnExit)))
 
 (defmacro with-ephemeral-file
@@ -91,6 +95,11 @@
   (with-ephemeral-package-json project
     (println "lein-npm generated package.json:\n")
     (println (slurp (package-file-from-project project)))))
+
+(defn dump-package
+  [project]
+  (write-file (package-file-from-project project)
+              (project->package project)))
 
 (def key-deprecations
   "Mappings from old keys to new keys in :npm."
@@ -129,6 +138,8 @@
      (cond
       (= ["pprint"] args)
       (npm-debug project)
+      (= ["dump-package"])
+      (dump-package project)
       :else
       (with-ephemeral-package-json project
         (apply invoke project args)))))


### PR DESCRIPTION
Addresses #24 - I didn't add an output paths/dir option - the file is written at the project root, like the ephemeral `package.json` (and so will prevent further `lein npm` operations so long as it remains there).

This covers my use case - more than happy to expand.
