### PR TITLE
add private npm module example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can specify a project's npm dependencies by adding an `:npm` map to your
                      [mongodb "1.2.7"]]}
 ```
 
-These dependencies, and any npm dependencies of packages pulled in through the
+You can specify private npm modules by passing a string for the scoped module name, such as `["@yr_npm_username/underscore" "1.4.3"]`.These dependencies, and any npm dependencies of packages pulled in through the
 regular `:dependencies`, will be installed through npm when you run either
 `lein npm install` or `lein deps`.
 


### PR DESCRIPTION
this tripped me up when i was trying to install a private module, but a string just worked :smile_cat: 