### PR TITLE
Only trying to process Jar files when resolving dependencies

### DIFF
--- a/src/leiningen/npm/deps.clj
+++ b/src/leiningen/npm/deps.clj
@@ -78,6 +78,12 @@
               [name (leiningen.core.user/resolve-credentials repo)]))
        (into {})))
 
+(defn- open-jars [fs]
+  (letfn [(trace [x] (println x) x)]
+    (->> fs
+         (filter #(.endsWith (.getName %) ".jar"))
+         (map #(JarFile. %)))))
+
 (defn- resolve-in-jar-deps
   "Finds dependencies in a project definition using lookup-deps in all the
   project definitions for jar dependencies of a project. Excludes any Clojure
@@ -86,7 +92,7 @@
   (->> (a/resolve-dependencies :coordinates (project :dependencies)
                                :repositories (resolve-repositories (project :repositories)))
        (a/dependency-files)
-       (map #(JarFile. %))
+       open-jars
        (keep (partial resolve-in-jar-dep lookup-deps exclusions))
        (reduce concat)))
 


### PR DESCRIPTION
I found a problem trying to use lein-npm in a project where I have brought a regular dependency that included the pom file:

``` clojure
:dependencies [
            ;; ...
             [org.apache.jena/apache-jena-libs "3.1.0" :extension "pom"]
            ;; ...
           ]
```

This dependency was making lein-npm fail because it was trying to open a pom file in the dependencies path as a Jar file.

In order to fix my problem, I just added a some filtering logic to only open files with `.jar` extension.
