### PR TITLE
Correct ephemeral environmental-consistency check.

### DIFF
--- a/src/leiningen/npm.clj
+++ b/src/leiningen/npm.clj
@@ -35,7 +35,7 @@
   [project]
   (when
     (and
-      (not (get-in project [:npm :ephemeral?]))
+      (not (false? (get-in project [:npm :ephemeral?])))
       (.exists (package-file-from-project project)))
     (do
       (println


### PR DESCRIPTION
Only abort when `ephemeral?` is `true` or `nil`.

If `ephemeral?` is `false` then the existence of the package file is expected.