### PR TITLE
Project dependencies should override dependencies of dependencies

### DIFF
--- a/src/leiningen/npm/deps.clj
+++ b/src/leiningen/npm/deps.clj
@@ -107,9 +107,9 @@
 
 (defn resolve-node-deps
   ([lookup-deps project]
-     (let [deps (concat (lookup-deps project)
-                        (resolve-in-jar-deps lookup-deps project (scan-checkouts-projects (:root project)))
-                        (resolve-in-checkouts-deps lookup-deps (:root project)))]
+     (let [deps (concat (resolve-in-jar-deps lookup-deps project (scan-checkouts-projects (:root project)))
+                        (resolve-in-checkouts-deps lookup-deps (:root project))
+                        (lookup-deps project))]
        deps))
   ([project]
      (resolve-node-deps default-lookup-deps project)))


### PR DESCRIPTION
Project dependencies end up at the beginning of this list, but then latter when this list is passed to `hash-map` if there are any duplicates then the later (to the right) win. This means that project dependencies can't override dependencies of dependencies.